### PR TITLE
Add formula display skill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,9 @@ DISCORD_CLIENT_ID=x
 ALLOWED_SERVER_IDS=1
 
 DEFAULT_MODEL=gpt-4
+
+# If set it True, the Bot will be able to handle complex latex equation expression
+# You have to install latex to your system if you set True
+USE_LATEX=False
+# Please set the font's name including language you want to use, and check it installed on your system 
+LATEX_FONT='Noto Sans CJK JP'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 __pycache__/
+*.log
+*.out

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv==0.21.*
 openai==1.14.2
 PyYAML==6.0
 dacite==1.6.*
+matplotlib==3.8.*

--- a/src/discord_cogs/chat.py
+++ b/src/discord_cogs/chat.py
@@ -222,15 +222,16 @@ async def process_response(thread: discord.Thread, response_data: ResponseData) 
                 )
             )
         else:
-            message_rendered = await message.render()
-            shorter_response = split_into_shorter_messages(message_rendered.content)
-            for i, response in enumerate(shorter_response):
-                # Send attachments with last message
-                if i == len(shorter_response) - 1:
-                    message_rendered.content = response
-                    sent_message = await thread.send(**message_rendered.asdict())
-                else:
-                    sent_message = await thread.send(response)
+            messages_rendered = await message.render()
+            for message_rendered in messages_rendered:
+                shorter_response = split_into_shorter_messages(message_rendered.content)
+                for i, response in enumerate(shorter_response):
+                    # Send attachments with last message
+                    if i == len(shorter_response) - 1:
+                        message_rendered.content = response
+                        sent_message = await thread.send(**message_rendered.asdict())
+                    else:
+                        sent_message = await thread.send(response)
 
     else:
         await thread.send(


### PR DESCRIPTION
# Pull Request - Add Partial Support for LaTeX Math Rendering

## Overview
This pull request introduces a partial support for rendering LaTeX math formulas. The aim is to enhance the visualization of math expressions within the Discord bot responses.

## Changes
- Implemented a function that detects inline LaTeX expressions.
- Adjusted the `matplotlib` plotting to handle LaTeX expressions.

## Impact
- The bot can now display simple LaTeX formulas in its responses, improving the readability of math-related content.
- More complex LaTeX expressions involving environments (such as `pmatrix`) are still not supported and will be considered in future updates.

## Notes
- Full LaTeX support would require integrating a complete LaTeX engine which could significantly impact the bot's performance. The current solution aims to strike a balance between functionality and efficiency.
- Further improvements and full LaTeX support might be explored.
