### PR TITLE
list command now takes offset.

### DIFF
--- a/src/discord_cogs/assistants.py
+++ b/src/discord_cogs/assistants.py
@@ -300,10 +300,12 @@ class Assistant(commands.Cog):
             await int.response.send_message(f"Failed to start chat {str(e)}", ephemeral=True)
 
     @app_commands.command(name="list")
-    async def list(self, int: discord.Interaction, max: int = MAX_ASSISTANT_LIST):
+    async def list(self, int: discord.Interaction, offset: int = 0,
+            max: int = MAX_ASSISTANT_LIST):
         """List available assistants with optional limit (default MAX_ASSISTANT_LIST)"""
         await int.response.defer()
-        assistants = await list_assistants(limit=max)
+        assistants = await list_assistants(limit=offset+max)
+        assistants = assistants[offset:]
         header = "Available Assistants 🤖 `[assistant_id] name - description`\n"
         rendered = "".join([f"```{assistant.render()}```" for assistant in assistants])
         await int.followup.send(content=f"{header}{rendered}")


### PR DESCRIPTION
When used with a large number of people, many assistants are created, but apparently the /list command is currently unable to display many assistants, and 20 is optimal.
So we added an offset option to the /list command.
This will allow us to show 20 assistants from any point in the overall list, so that past assistants will not be buried in history.