### PR TITLE
list and chat commands are now capable of searching for a string.

### DIFF
--- a/src/discord_cogs/assistants.py
+++ b/src/discord_cogs/assistants.py
@@ -14,7 +14,11 @@ from src.constants import (
     MAX_ASSISTANT_LIST,
     MAX_CHARS_PER_REPLY_MSG,
 )
-from src.discord_cogs._utils import should_block, split_into_shorter_messages
+from src.discord_cogs._utils import (
+    search_assistants,
+    should_block,
+    split_into_shorter_messages,
+)
 from src.models.assistant import AssistantCreate
 from src.openai_api.assistants import (
     create_assistant,
@@ -327,10 +331,10 @@ class Assistant(commands.Cog):
 
     @app_commands.command(name="list")
     async def list(self, int: discord.Interaction, offset: int = 0,
-            max: int = MAX_ASSISTANT_LIST):
+            max: int = MAX_ASSISTANT_LIST, search: str = ''):
         """List available assistants with optional limit (default MAX_ASSISTANT_LIST)"""
         await int.response.defer()
-        assistants = await list_assistants(limit=offset+max)
+        assistants = await search_assistants(search=search, limit=offset+max)
         assistants = assistants[offset:]
         s = "Available Assistants 🤖 `[assistant_id] name - description`\n"
         for assistant in assistants:

--- a/src/discord_cogs/chat.py
+++ b/src/discord_cogs/chat.py
@@ -13,6 +13,7 @@ from discord.ui import Select, View
 from src.constants import ACTIVATE_CHAT_THREAD_PREFIX, MAX_ASSISTANT_LIST
 from src.discord_cogs._utils import (
     is_last_message_stale,
+    search_assistants,
     should_block,
     split_into_shorter_messages,
 )
@@ -30,8 +31,9 @@ class Chat(commands.Cog):
         self.bot = bot
 
     @app_commands.command(name="chat")
-    async def chat(self, int: discord.Interaction, assistant_id : str = "Not selected",
-            thread_id : str = None):
+    async def chat(self, int: discord.Interaction,
+            assistant_id: str = "Not selected",
+            thread_id: str = None, search: str = ''):
         """Start a chat with the bot in a thread"""
         try:
             # only support creating thread in text channel
@@ -79,7 +81,7 @@ class Chat(commands.Cog):
 
             # Show assistants as a select menu
             view = SelectView(thread=thread)
-            assistants = await list_assistants(MAX_ASSISTANT_LIST)
+            assistants = await search_assistants(search=search)
             for assistant in assistants:
                 view.selectMenu.add_option(
                     label=assistant.name,

--- a/src/openai_api/assistants.py
+++ b/src/openai_api/assistants.py
@@ -15,8 +15,13 @@ async def create_assistant(cfg: AssistantCreate) -> Assistant:
     return Assistant.from_api_output(response)
 
 
-async def list_assistants(limit: int = "20", order: str = "desc") -> list[Assistant]:
-    response = await client.beta.assistants.list(limit=limit, order=order)
+async def list_assistants(limit: int = "20", order: str = "desc",
+        after: str = '') -> list[Assistant]:
+    if after == '':
+        response = await client.beta.assistants.list(limit=limit, order=order)
+    else:
+        response = await client.beta.assistants.list(limit=limit, order=order,
+                after=after)
     assistants = []
     for d in response.data:
         assistants.append(Assistant.from_api_output(d))


### PR DESCRIPTION
- If a search string is specified, /list command retrieves the list of assistants that contain it, then processes the offset from the top and the maximum number to return.
- If a search string is specified, /chat command will retrieve up to 20 assistants that contain it and allow them to be selected from a pull-down menu.